### PR TITLE
fix : hide env secrets on gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel


### PR DESCRIPTION
.env file is a sensitive file that should be kept private for your local env consider deleting from local before doing future commit 
and gitignore will handle to hide this file.


If you consider removing .env from all git history: https://git.wtf/removing-env-file-from-git-history/ 